### PR TITLE
Fix creating LLD rule

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -138,9 +138,7 @@ def create_zbx_host(
         hostid=host_id,
         name=lld_name,
         key_=lld_key,
-        value_type="4",
         trapper_hosts="",
-        units="",
         lifetime="0",
     )["itemids"][0]
 


### PR DESCRIPTION
This PR fixes such errors
```
$  ./prepare.py -v
Connected to Zabbix API v.7.0.5
...
Traceback (most recent call last):
  File "/home/user/work/zabbix-threat-control/./prepare.py", line 652, in <module>
    create_hosts()
  File "/home/user/work/zabbix-threat-control/./prepare.py", line 231, in create_hosts
    create_zbx_host(
  File "/home/user/work/zabbix-threat-control/./prepare.py", line 136, in create_zbx_host
    lld_id = zapi.discoveryrule.create(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/work/zabbix-threat-control/.venv/lib/python3.12/site-packages/pyzabbix/__init__.py", line 217, in fn
    return self.parent.do_request(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/work/zabbix-threat-control/.venv/lib/python3.12/site-packages/pyzabbix/__init__.py", line 196, in do_request
    raise ZabbixAPIException(msg, response_json['error']['code'], error=response_json['error'])
pyzabbix.ZabbixAPIException: ('Error -32602: Invalid params., Invalid parameter "/1": unexpected parameter "units".', -32602)
```
and
```
...
 File "/home/user/work/zabbix-threat-control/.venv/lib/python3.12/site-packages/pyzabbix/__init__.py", line 196, in do_request
    raise ZabbixAPIException(msg, response_json['error']['code'], error=response_json['error'])
pyzabbix.ZabbixAPIException: ('Error -32602: Invalid params., Invalid parameter "/1": unexpected parameter "value_type".', -32602)
```