### PR TITLE
backslash escape fix

### DIFF
--- a/os-report/scan_modules/nix_detect.py
+++ b/os-report/scan_modules/nix_detect.py
@@ -15,8 +15,8 @@ class NixDetect(ScannerInterface):
     def get_ip(self):
         return self.execute_cmd(
             "ifconfig | "
-            "grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | "
-            "grep -Eo '([0-9]*\.){3}[0-9]*' | "
+            "grep -Eo 'inet (addr:)?([0-9]*\\.){3}[0-9]*' | "
+            "grep -Eo '([0-9]*\\.){3}[0-9]*' | "
             "grep -v '127.0.0.1' | "
             "head -1"
         )


### PR DESCRIPTION
In Python, the backslash \ inside normal string literals starts an escape sequence (for example, \n = newline, \t = tab).
The sequence \. isn’t a valid escape sequence — so Python raises a warning:

SyntaxWarning: invalid escape sequence '\.'

In some cases, this warning appears in the values of Vulners data elements in Zabbix (OS - Name etc)